### PR TITLE
fix deb packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,2 +1,21 @@
 Source: kodi-inputstream-rtmp
+Priority: extra
+Maintainer: Arne Morten Kvarving <spiff@xbmc.org>
+Build-Depends: debhelper (>= 9.0.0), cmake, libkodiplatform-dev (>= 17.0.0),
+               kodi-addon-dev, kodi-inputstream-dev, pkg-config, libssl-dev, zlib1g-dev, librtmp-dev
+Standards-Version: 3.9.6
+Section: libs
 
+Package: kodi-inputstream-rtmp
+Section: libs
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: Rtmp inputstream addon for Kodi
+ This is the RTMP inputstream addon for Kodi
+
+Package: kodi-inputstream-rtmp-dbg
+Section: libs
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: debug symbols for RTMP inputstream addon for Kodi
+ debug symbols for RTMP inputstream addon for Kodi

--- a/debian/kodi-inputstream-rtmp.install
+++ b/debian/kodi-inputstream-rtmp.install
@@ -1,0 +1,2 @@
+usr/lib
+usr/share

--- a/debian/rules
+++ b/debian/rules
@@ -10,16 +10,13 @@
 #export DH_VERBOSE=1
 
 %:
-	dh $@ 
+	dh $@ --parallel
 
 override_dh_auto_configure:
 	dh_auto_configure -- -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DUSE_LTO=1
 
 override_dh_strip:
-	dh_strip --dbg-package=kodi-inputstream-rtmp-dbg
-
-override_dh_auto_install:
-	dh_auto_install --destdir=debian/kodi-inputstream-rtmp
+	dh_strip -pkodi-inputstream.rtmp --dbg-package=kodi-inputstream-rtmp-dbg
 
 override_dh_installdocs:
 	dh_installdocs --link-doc=kodi-inputstream-rtmp


### PR DESCRIPTION
warning: this assumes kodi has been installed in debian multi-arch dirs.
So it needs https://github.com/xbmc/xbmc/pull/10359 