### PR TITLE
Fix OpenSSL

### DIFF
--- a/depends/common/librtmp/CMakeLists.txt
+++ b/depends/common/librtmp/CMakeLists.txt
@@ -12,7 +12,7 @@ include(ExternalProject)
 externalproject_add(librtmp
                     SOURCE_DIR ${CMAKE_SOURCE_DIR}
                     CONFIGURE_COMMAND ""
-                    BUILD_COMMAND cd <SOURCE_DIR> && make -C librtmp SHARED= prefix=${OUTPUT_DIR} SYS=${SYS} XCFLAGS=-fpic
+                    BUILD_COMMAND cd <SOURCE_DIR> && make -C librtmp SHARED= prefix=${OUTPUT_DIR} INC=-I${OUTPUT_DIR}/include SYS=${SYS} XCFLAGS=-fpic
                     INSTALL_COMMAND "")
 
 install(CODE "execute_process(COMMAND make -C librtmp install

--- a/depends/common/librtmp/CMakeLists.txt
+++ b/depends/common/librtmp/CMakeLists.txt
@@ -1,10 +1,11 @@
 project(librtmp)
 
 cmake_minimum_required(VERSION 2.8)
-set(SYS posix)
-if(CORE_SYSTEM_NAME MATCHES "osx" OR
-   CORE_SYSTEM_NAMES MATCHES "ios")
+
+if(CORE_SYSTEM_NAME STREQUAL osx OR CORE_SYSTEM_NAME STREQUAL ios)
   set(SYS darwin)
+else()
+  set(SYS posix)
 endif()
 
 include(ExternalProject)

--- a/depends/common/openssl/CMakeLists.txt
+++ b/depends/common/openssl/CMakeLists.txt
@@ -40,10 +40,8 @@ externalproject_add(openssl
                     INSTALL_COMMAND ""
                     BUILD_IN_SOURCE 1)
 
-install(CODE "execute_process(COMMAND make install_sw
-                              WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-                              COMMAND rm -f ${OUTPUT_DIR}/lib/libcrypto.so*
-                              COMMAND rm -f ${OUTPUT_DIR}/lib/libssl.so*
-                              COMMAND rm -f ${OUTPUT_DIR}/lib/libcrypto*dylib*
-                              COMMAND rm -f ${OUTPUT_DIR}/lib/libssl*dylib*
-                              WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})")
+install(CODE "execute_process(COMMAND make install_sw WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+              execute_process(COMMAND rm -f ${OUTPUT_DIR}/lib/libcrypto.so* WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+              execute_process(COMMAND rm -f ${OUTPUT_DIR}/lib/libssl.so* WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+              execute_process(COMMAND rm -f ${OUTPUT_DIR}/lib/libcrypto*dylib* WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+              execute_process(COMMAND rm -f ${OUTPUT_DIR}/lib/libssl*dylib* WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})")


### PR DESCRIPTION
Followup on my questions in https://github.com/notspiff/inputstream.rtmp/commit/e5e4cee142c6614664448318c7b3df3b3809930e.

OpenSSL was really not installed neither on Jenkins nor locally. We always got a broken pipe error because all the following commands were just passed to make.
On Jenkins OSX, the Xcode version ships a local openssl library in default paths. On linux also the host lib is found.