### PR TITLE
[depends] fix openssl install when INSTALL_PREFIX env var is set

### DIFF
--- a/depends/common/openssl/CMakeLists.txt
+++ b/depends/common/openssl/CMakeLists.txt
@@ -5,8 +5,9 @@ cmake_minimum_required(VERSION 2.8)
 include(ExternalProject)
 
 if(CORE_SYSTEM_NAME MATCHES "android")
-  set(configure_command CC=${CMAKE_C_COMPILER} AR=${CMAKE_AR}
+  set(configure_command CC=${CMAKE_C_COMPILER} AR=${CMAKE_AR} INSTALL_PREFIX=""
                         <SOURCE_DIR>/Configure no-shared zlib
+                        --install_prefix=""
                         --openssldir=${OUTPUT_DIR}
                         --with-zlib-include=${OUTPUT_DIR}/include
                         --with-zlib-lib=${OUTPUT_DIR}/lib
@@ -22,8 +23,9 @@ if(CORE_SYSTEM_NAME MATCHES "linux")
       set(bitness 32)
     endif()
 
-    set(configure_command CC=${CMAKE_C_COMPILER} AR=${CMAKE_AR}
+    set(configure_command CC=${CMAKE_C_COMPILER} AR=${CMAKE_AR} INSTALL_PREFIX=""
                           <SOURCE_DIR>/Configure no-shared zlib
+                          --install_prefix=""
                           --openssldir=${OUTPUT_DIR}
                           --with-zlib-include=${OUTPUT_DIR}/include
                           --with-zlib-lib=${OUTPUT_DIR}/lib
@@ -36,7 +38,10 @@ if(CORE_SYSTEM_NAME MATCHES "linux")
 endif()
 
 if(CORE_SYSTEM_NAME MATCHES "ios")
-  set(configure_command CC=${CMAKE_COMPILER} AR=${CMAKE_AR} <SOURCE_DIR>/Configure iphoneos-cross zlib no-asm no-krb5 --openssldir=${OUTPUT_DIR}
+  set(configure_command CC=${CMAKE_COMPILER} AR=${CMAKE_AR} INSTALL_PREFIX=""
+                        <SOURCE_DIR>/Configure iphoneos-cross zlib no-asm no-krb5
+                        --openssldir=${OUTPUT_DIR}
+                        --install_prefix=""
       && sed -ie "s|CFLAG= |CFLAG=${CMAKE_C_FLAGS} |" ${PROJECT_SOURCE_DIR}/Makefile
       && sed -ie "s|-isysroot $.CROSS_TOP./SDKs/$.CROSS_SDK. ||" ${PROJECT_SOURCE_DIR}/Makefile
       && sed -ie "s|apps test||" ${PROJECT_SOURCE_DIR}/Makefile
@@ -60,7 +65,8 @@ externalproject_add(openssl
                     INSTALL_COMMAND ""
                     BUILD_IN_SOURCE 1)
 
-install(CODE "execute_process(COMMAND make install_sw WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+install(CODE "execute_process(COMMAND find ${CMAKE_SOURCE_DIR} -name Makefile -exec sed -ie s|INSTALL_PREFIX|stupidshit|g {} \;)
+              execute_process(COMMAND make install_sw WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
               execute_process(COMMAND rm -f ${OUTPUT_DIR}/lib/libcrypto.so* WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
               execute_process(COMMAND rm -f ${OUTPUT_DIR}/lib/libssl.so* WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
               execute_process(COMMAND rm -f ${OUTPUT_DIR}/lib/libcrypto*dylib* WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})


### PR DESCRIPTION
Apparently jenkins sets an env var INSTALL_PREFIX, which bleeds into the openssl Makefile, cause someone decided to use $(INSTALL_PREFIX) where everyone else uses $(DESTDIR)....

this PR fixes openssl build and install on all platforms, and addon build on android and linux

overall addon build (still) fails on osx/ios, with this linker error:
>[100%] Linking CXX shared library inputstream.rtmp.dylib
/Users/Shared/jenkins/workspace/OSX-64/tools/depends/xbmc-depends/buildtools-native/bin/cmake -E cmake_link_script CMakeFiles/inputstream.rtmp.dir/link.txt --verbose=1
/usr/bin/clang++  -no-cpp-precomp -arch x86_64 -mmacosx-version-min=10.8 -std=c++11 -stdlib=libc++ -g -O2 -std=gnu++11 -g -D_DEBUG -isysroot /Applications/Xcode6.1.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk  -O3 -DNDEBUG -isysroot /Applications/Xcode6.1.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk -dynamiclib -Wl,-headerpad_max_install_names  -Wl,-search_paths_first -arch x86_64 -mmacosx-version-min=10.8 -isysroot /Applications/Xcode6.1.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk -stdlib=libc++   -compatibility_version 17.0.0 -current_version 1.0.1 -o inputstream.rtmp.1.0.1.dylib -install_name /Users/Shared/jenkins/workspace/OSX-64/tools/depends/target/binary-addons/macosx10.10_x86_64-target/inputstream.rtmp-prefix/src/inputstream.rtmp-build/inputstream.rtmp.17.0.dylib CMakeFiles/inputstream.rtmp.dir/src/RTMPStream.cpp.o /Users/Shared/jenkins/workspace/OSX-64/tools/depends/target/binary-addons/macosx10.10_x86_64-target/build/depends/lib/librtmp.a /Applications/Xcode6.1.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/usr/lib/libssl.dylib /Applications/Xcode6.1.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/usr/lib/libcrypto.dylib /Users/Shared/jenkins/workspace/OSX-64/tools/depends/target/binary-addons/macosx10.10_x86_64-target/build/depends/lib/libz.a 
Undefined symbols for architecture x86_64:
  "_netstackdump", referenced from:
      _RTMP_Connect1 in librtmp.a(rtmp.o)
      _ReadN in librtmp.a(rtmp.o)
      _WriteN in librtmp.a(rtmp.o)
      _CloseInternal in librtmp.a(rtmp.o)
      _RTMPSockBuf_Send in librtmp.a(rtmp.o)
  "_netstackdump_read", referenced from:
      _ReadN in librtmp.a(rtmp.o)
ld: symbol(s) not found for architecture x86_64

see http://jenkins.kodi.tv/job/OSX-64/9717/consoleText
I don't have time (and hardware) to look into this further, maybe someone else cares enough..
@fetzerch fyi