### PR TITLE
[depends] librtmp: get rid of undefined symbols by undefining _DEBUG

### DIFF
--- a/depends/common/librtmp/CMakeLists.txt
+++ b/depends/common/librtmp/CMakeLists.txt
@@ -16,7 +16,7 @@ externalproject_add(librtmp
                     CONFIGURE_COMMAND ""
                     BUILD_COMMAND cd <SOURCE_DIR>
                                   && make -C librtmp SHARED= prefix=${OUTPUT_DIR} INC=-I${OUTPUT_DIR}/include SYS=${SYS}
-                                     XCFLAGS=${cflags} CC=${CMAKE_C_COMPILER} AR=${CMAKE_AR} XLDFLAGS=${OUTPUT_DIR}/lib
+                                     XCFLAGS=${cflags} XDEF=-U_DEBUG CC=${CMAKE_C_COMPILER} AR=${CMAKE_AR} XLDFLAGS=${OUTPUT_DIR}/lib
                     INSTALL_COMMAND "")
 
 install(CODE "execute_process(COMMAND make -C librtmp install


### PR DESCRIPTION
fixes build on darwin

there were unresolved symbols netstackstrace* on all platforms, but only darwin complained about it.
No idea how this is supposed to work, but when _DEBUG is defined, librtmp adds a pointer to an non-existing file... Lets get rid of it.