### PR TITLE
windows: fix unresolved externals for Krypton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,12 @@ enable_language(CXX)
 
 find_package(PkgConfig)
 find_package(Kodi REQUIRED)
+find_package(p8-platform REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(RTMP REQUIRED)
+
+list(APPEND DEPLIBS ${p8-platform_LIBRARIES})
 
 set(RTMP_SOURCES src/RTMPStream.cpp)
 


### PR DESCRIPTION
Can you please make a version bump and create a tag after merging this PR that it can get into Krypton.