### PR TITLE
[debian] fix dbg package generation and build on ubuntu 18.04

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -16,7 +16,7 @@ override_dh_auto_configure:
 	dh_auto_configure -- -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DUSE_LTO=1
 
 override_dh_strip:
-	dh_strip -pkodi-inputstream.rtmp --dbg-package=kodi-inputstream-rtmp-dbg
+	dh_strip -pkodi-inputstream-rtmp --dbg-package=kodi-inputstream-rtmp-dbg
 
 override_dh_installdocs:
 	dh_installdocs --link-doc=kodi-inputstream-rtmp


### PR DESCRIPTION
apparently this is now an error 