### PR TITLE
[darwin_embedded] Update for PR 16039

### DIFF
--- a/depends/common/librtmp/CMakeLists.txt
+++ b/depends/common/librtmp/CMakeLists.txt
@@ -2,7 +2,7 @@ project(librtmp)
 
 cmake_minimum_required(VERSION 2.8)
 
-if(CORE_SYSTEM_NAME STREQUAL osx OR CORE_SYSTEM_NAME STREQUAL ios)
+if(CORE_SYSTEM_NAME STREQUAL osx OR CORE_SYSTEM_NAME STREQUAL darwin_embedded)
   set(SYS darwin)
 else()
   set(SYS posix)

--- a/depends/common/openssl/CMakeLists.txt
+++ b/depends/common/openssl/CMakeLists.txt
@@ -45,7 +45,7 @@ if(CORE_SYSTEM_NAME MATCHES "linux" OR CORE_SYSTEM_NAME MATCHES "rbpi")
   endif()
 endif()
 
-if(CORE_SYSTEM_NAME MATCHES "ios")
+if(CORE_SYSTEM_NAME MATCHES "darwin_embedded")
   set(configure_command CC=${CMAKE_COMPILER} AR=${CMAKE_AR} INSTALL_PREFIX=""
                         <SOURCE_DIR>/Configure iphoneos-cross no-shared zlib no-asm
                         --prefix=${OUTPUT_DIR}


### PR DESCRIPTION
Change to Darwin_embedded for CORE_SYSTEM_NAME to suit https://github.com/xbmc/xbmc/pull/16039