### PR TITLE
Fix struct initializations

### DIFF
--- a/inputstream.rtmp/addon.xml.in
+++ b/inputstream.rtmp/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.rtmp"
-  version="2.0.6"
+  version="2.0.7"
   name="RTMP Input"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/RTMPStream.cpp
+++ b/src/RTMPStream.cpp
@@ -125,12 +125,14 @@ void CInputStreamRTMP::GetCapabilities(INPUTSTREAM_CAPABILITIES &caps)
 
 INPUTSTREAM_IDS CInputStreamRTMP::GetStreamIds()
 {
-  return INPUTSTREAM_IDS();
+  INPUTSTREAM_IDS ids = { 0 };
+  return ids;
 }
 
 INPUTSTREAM_INFO CInputStreamRTMP::GetStream(int streamid)
 {
-  return INPUTSTREAM_INFO();
+  INPUTSTREAM_INFO info = { INPUTSTREAM_INFO::STREAM_TYPE::TYPE_NONE };
+  return info;
 }
 
 void CInputStreamRTMP::EnableStream(int streamid, bool enable)


### PR DESCRIPTION
The INPUTSTREAM_IDS and INPUTSTREAM_INFO structs are defined as
C structs, initializing by constructor may leave struct members
uninitialized.

See the discussion in https://github.com/xbmc/xbmc/pull/17233 for reasons why this can not easily be fixed in the base class.

Fixes https://github.com/xbmc/inputstream.rtmp/issues/27