### PR TITLE
[cleanup] use default initializers for member variables

### DIFF
--- a/src/RTMPStream.cpp
+++ b/src/RTMPStream.cpp
@@ -62,14 +62,12 @@ public:
   virtual bool CanSeekStream() override { return true; }
 
 private:
-  RTMP* m_session;
-  bool m_paused;
+  RTMP* m_session = nullptr;
+  bool m_paused = false;
 };
 
 CInputStreamRTMP::CInputStreamRTMP(KODI_HANDLE instance)
-  : CInstanceInputStream(instance),
-    m_session(nullptr),
-    m_paused(false)
+  : CInstanceInputStream(instance)
 {
 }
 


### PR DESCRIPTION
Just a minor cleanup. Mainly opened this pull request to check if the AppVeyor build is broken here as well or just on #55 