### PR TITLE
Inputstream API change to v2.1.0 - RTMP version 3.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ debian/*.log
 debian/*.substvars
 debian/.debhelper/
 debian/tmp/
-debian/kodi-inputstream-*/
+debian/kodi-pvr-*/
 obj-x86_64-linux-gnu/
 
 # commonly used editors
@@ -37,6 +37,9 @@ obj-x86_64-linux-gnu/
 
 # to prevent add after a "git format-patch VALUE" and "git add ." call
 /*.patch
+
+# Visual Studio Code
+.vscode
 
 # to prevent add if project code opened by Visual Studio over CMake file
 .vs/

--- a/inputstream.rtmp/addon.xml.in
+++ b/inputstream.rtmp/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.rtmp"
-  version="3.0.1"
+  version="3.0.2"
   name="RTMP Input"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/RTMPStream.cpp
+++ b/src/RTMPStream.cpp
@@ -62,8 +62,6 @@ public:
   bool PosTime(int ms) override;
   int GetTotalTime() override { return 20; }
   int GetTime() override { return 0; }
-  bool CanPauseStream() override { return true; }
-  bool CanSeekStream() override { return true; }
 
 private:
   RTMP* m_session = nullptr;
@@ -125,6 +123,8 @@ void CInputStreamRTMP::Close()
 void CInputStreamRTMP::GetCapabilities(INPUTSTREAM_CAPABILITIES &caps)
 {
   caps.m_mask |= INPUTSTREAM_CAPABILITIES::SUPPORTS_IPOSTIME;
+  caps.m_mask |= INPUTSTREAM_CAPABILITIES::SUPPORTS_SEEK;
+  caps.m_mask |= INPUTSTREAM_CAPABILITIES::SUPPORTS_PAUSE;
 }
 
 INPUTSTREAM_IDS CInputStreamRTMP::GetStreamIds()


### PR DESCRIPTION
Minor API update to remove 2 unused function calls, modify PauseStream signature and increase num stream properties allowed in inputstream addons.

Kodi PR: xbmc/xbmc#17620

Do not merge yet.