### PR TITLE
v3.1.1 - Bump version for PPA build Global API 1.2.0 and inputstream API 2.3.1

### DIFF
--- a/inputstream.rtmp/addon.xml.in
+++ b/inputstream.rtmp/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.rtmp"
-  version="3.1.0"
+  version="3.1.1"
   name="RTMP Input"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>
@@ -23,6 +23,9 @@ This addon implements RTMP streaming support for Kodi and installed add-ons.
       <icon>icon.png</icon>
     </assets>
     <news>
+v3.1.1
+- Bump verion for PPA build Global API 1.2.0 and inputstream API 2.3.1
+
 v3.1.0
 - Matrix API change inputstream API 2.3.1
 - Matrix APi change Global API 1.2.0


### PR DESCRIPTION
v3.1.1
- Bump version for PPA build Global API 1.2.0 and inputstream API 2.3.1