### PR TITLE
[Nexus] initial release change for new Kodi 20 Nexus version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix")
+buildPlugin(version: "Nexus")

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 This is a [Kodi](https://kodi.tv) input stream addon for RTMP.
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.inputstream.rtmp?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=29&branchName=Matrix)
-[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/inputstream.rtmp/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Finputstream.rtmp/branches/)
-<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/inputstream.rtmp?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/inputstream-rtmp?branch=Matrix) -->
+[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.inputstream.rtmp?branchName=Nexus)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=29&branchName=Nexus)
+[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/inputstream.rtmp/job/Nexus/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Finputstream.rtmp/branches/)
+<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/inputstream.rtmp?branch=Nexus&svg=true)](https://ci.appveyor.com/project/xbmc/inputstream-rtmp?branch=Nexus) -->
 
 ## Build instructions
 
@@ -19,7 +19,7 @@ The following instructions assume you will have built Kodi already in the `kodi-
 suggested by the README.
 
 1. `git clone --branch master https://github.com/xbmc/xbmc.git`
-2. `git clone --branch Matrix https://github.com/xbmc/inputstream.rtmp.git`
+2. `git clone --branch Nexus https://github.com/xbmc/inputstream.rtmp.git`
 3. `cd inputstream.rtmp && mkdir build && cd build`
 4. `cmake -DADDONS_TO_BUILD=inputstream.rtmp -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/kodi-build/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons`
 5. `make`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ variables:
 trigger:
   branches:
     include:
-    - Matrix
+    - Nexus
     - releases/*
   paths:
     include:

--- a/inputstream.rtmp/addon.xml.in
+++ b/inputstream.rtmp/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.rtmp"
-  version="3.4.0"
+  version="20.0.0"
   name="RTMP Input"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>
@@ -18,7 +18,14 @@
     <assets>
       <icon>icon.png</icon>
     </assets>
-    <news>v3.4.0
+    <news>v20.0.0
+- Changed test builds to 'Kodi 20 Nexus'
+- Prepared for new language translation by Weblate
+- Increased version to 20.0.0
+  - With start of Kodi 20 Nexus, takes addon as major the same version number as Kodi.
+    This done to know easier to which Kodi the addon works.
+
+v3.4.0
 - Update: inputstream API 3.0.1
   - Fix wrong flags bit shift
 


### PR DESCRIPTION
This change the builds to Kodi Nexus.

Further is the version to 20.0.0 increased to have equal to Kodi and to see on which Version this addon works.