### PR TITLE
Release osx-amd64 support

### DIFF
--- a/inputstream.rtmp/addon.xml.in
+++ b/inputstream.rtmp/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.rtmp"
-  version="20.2.0"
+  version="20.2.1"
   name="RTMP Input"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/inputstream.rtmp/changelog.txt
+++ b/inputstream.rtmp/changelog.txt
@@ -1,3 +1,6 @@
+v20.2.1:
+- Support osx-amd64 OpenSSL dependency
+
 v20.2.0:
 - Version bump because of inputstream API bump
 


### PR DESCRIPTION
v20.2.1:
- Support osx-amd64 OpenSSL dependency