### PR TITLE
Tag version 22.0.2

### DIFF
--- a/inputstream.rtmp/addon.xml.in
+++ b/inputstream.rtmp/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.rtmp"
-  version="22.0.1"
+  version="22.0.2"
   name="RTMP Input"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/inputstream.rtmp/changelog.txt
+++ b/inputstream.rtmp/changelog.txt
@@ -1,3 +1,8 @@
+v22.0.2
+- Kodi inputstream API update to version 3.4.0
+- Translation updates by Weblate
+- Update dependencies (openssl, zlib)
+
 v21.1.0
 - Kodi inputstream API update to version 3.3.0
 


### PR DESCRIPTION
As requested by @CastagnaIT 

Required to bump version of addon as inputstream API increasing to v3.4.0 when the following PR is merged:

https://github.com/xbmc/xbmc/pull/27136